### PR TITLE
Set default keyArgs to false

### DIFF
--- a/src/createPaginationLink.ts
+++ b/src/createPaginationLink.ts
@@ -45,7 +45,7 @@ export function createPaginationLink(
         const keyArgs =
           (keyArgsArg?.value as ListValueNode)?.values.map(
             v => (v as StringValueNode).value
-          ) ?? [];
+          ) ?? false;
 
         // Check if the policies are already applied
         const key = `${typename}-${field.name.value}`;


### PR DESCRIPTION
if there are no keyArgs provided, set default keyArgs to `false` not empty array.
[`false` for keyArgs indicates that the field has no key arguments.](https://www.apollographql.com/docs/react/pagination/key-args/#supported-values-for-keyargs)

